### PR TITLE
THE-889: More robust error handling in generated spec

### DIFF
--- a/nile_api/api/access/create_policy.py
+++ b/nile_api/api/access/create_policy.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.create_policy_request import CreatePolicyRequest
+from ...models.error import Error
 from ...models.policy import Policy
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Policy]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Policy]:

--- a/nile_api/api/access/delete_policy.py
+++ b/nile_api/api/access/delete_policy.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -31,7 +32,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/access/get_policy.py
+++ b/nile_api/api/access/get_policy.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -35,12 +36,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Policy]:
         response_200 = Policy.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Policy]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/access/get_policy.py
+++ b/nile_api/api/access/get_policy.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.policy import Policy
 from ...types import Response
 
@@ -44,7 +45,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Policy]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Policy]:

--- a/nile_api/api/access/list_policies.py
+++ b/nile_api/api/access/list_policies.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.policy import Policy
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Policy]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Policy]]:

--- a/nile_api/api/access/list_policies.py
+++ b/nile_api/api/access/list_policies.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Policy]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Policy]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/access/update_policy.py
+++ b/nile_api/api/access/update_policy.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.policy import Policy
 from ...models.update_policy_request import UpdatePolicyRequest
 from ...types import Response
@@ -49,7 +50,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Policy]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Policy]:

--- a/nile_api/api/access/update_policy.py
+++ b/nile_api/api/access/update_policy.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -40,12 +41,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Policy]:
         response_200 = Policy.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Policy]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/developers/create_developer.py
+++ b/nile_api/api/developers/create_developer.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.create_user_request import CreateUserRequest
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -44,7 +45,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/developers/create_developer.py
+++ b/nile_api/api/developers/create_developer.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -35,12 +36,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_201 = User.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/developers/developer_google_o_auth_callback.py
+++ b/nile_api/api/developers/developer_google_o_auth_callback.py
@@ -7,6 +7,7 @@ from ...client import Client
 from ...models.developer_google_o_auth_response import (
     DeveloperGoogleOAuthResponse,
 )
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -58,7 +59,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/developers/login_developer.py
+++ b/nile_api/api/developers/login_developer.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -42,14 +43,22 @@ def _parse_response(
         response_401 = Error.from_dict(response.json())
 
         return response_401
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Error, Token]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/developers/login_developer.py
+++ b/nile_api/api/developers/login_developer.py
@@ -51,7 +51,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/developers/start_developer_google_o_auth.py
+++ b/nile_api/api/developers/start_developer_google_o_auth.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Union
 
 import httpx
@@ -35,7 +36,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/developers/validate_developer.py
+++ b/nile_api/api/developers/validate_developer.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union, cast
 
 import httpx
@@ -40,14 +41,22 @@ def _parse_response(
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Any, Error]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/developers/validate_developer.py
+++ b/nile_api/api/developers/validate_developer.py
@@ -49,7 +49,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/entities/create_entity.py
+++ b/nile_api/api/entities/create_entity.py
@@ -6,6 +6,7 @@ import httpx
 from ...client import Client
 from ...models.create_entity_request import CreateEntityRequest
 from ...models.entity import Entity
+from ...models.error import Error
 from ...types import Response
 
 
@@ -47,7 +48,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:

--- a/nile_api/api/entities/create_entity.py
+++ b/nile_api/api/entities/create_entity.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -38,12 +39,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
         response_200 = Entity.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/create_instance.py
+++ b/nile_api/api/entities/create_instance.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance import Instance
 from ...models.json_schema_instance import JsonSchemaInstance
 from ...types import Response
@@ -49,7 +50,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:

--- a/nile_api/api/entities/create_instance.py
+++ b/nile_api/api/entities/create_instance.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -40,12 +41,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
         response_201 = Instance.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/delete_instance.py
+++ b/nile_api/api/entities/delete_instance.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -32,7 +33,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/entities/get_entity.py
+++ b/nile_api/api/entities/get_entity.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.entity import Entity
+from ...models.error import Error
 from ...types import Response
 
 
@@ -43,7 +44,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:

--- a/nile_api/api/entities/get_entity.py
+++ b/nile_api/api/entities/get_entity.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -34,12 +35,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
         response_200 = Entity.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/get_instance.py
+++ b/nile_api/api/entities/get_instance.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -36,12 +37,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
         response_200 = Instance.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/get_instance.py
+++ b/nile_api/api/entities/get_instance.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance import Instance
 from ...types import Response
 
@@ -45,7 +46,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:

--- a/nile_api/api/entities/get_open_api.py
+++ b/nile_api/api/entities/get_open_api.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -30,7 +31,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/entities/instance_events.py
+++ b/nile_api/api/entities/instance_events.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance_event import InstanceEvent
 from ...types import UNSET, Response, Unset
 
@@ -62,7 +63,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/entities/instance_events.py
+++ b/nile_api/api/entities/instance_events.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
@@ -53,14 +54,22 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[List[InstanceEvent]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/list_entities.py
+++ b/nile_api/api/entities/list_entities.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -38,12 +39,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Entity]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Entity]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/list_entities.py
+++ b/nile_api/api/entities/list_entities.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.entity import Entity
+from ...models.error import Error
 from ...types import Response
 
 
@@ -47,7 +48,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Entity]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Entity]]:

--- a/nile_api/api/entities/list_instances.py
+++ b/nile_api/api/entities/list_instances.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance import Instance
 from ...types import Response
 
@@ -49,7 +50,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Instance]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Instance]]:

--- a/nile_api/api/entities/list_instances.py
+++ b/nile_api/api/entities/list_instances.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -40,12 +41,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Instance]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Instance]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/list_instances_in_workspace.py
+++ b/nile_api/api/entities/list_instances_in_workspace.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance import Instance
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Instance]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Instance]]:

--- a/nile_api/api/entities/list_instances_in_workspace.py
+++ b/nile_api/api/entities/list_instances_in_workspace.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Instance]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Instance]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/update_entity.py
+++ b/nile_api/api/entities/update_entity.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
         response_200 = Entity.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/entities/update_entity.py
+++ b/nile_api/api/entities/update_entity.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.entity import Entity
+from ...models.error import Error
 from ...models.update_entity_request import UpdateEntityRequest
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Entity]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Entity]:

--- a/nile_api/api/entities/update_instance.py
+++ b/nile_api/api/entities/update_instance.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.instance import Instance
 from ...models.update_instance_request import UpdateInstanceRequest
 from ...types import UNSET, Response, Unset
@@ -54,7 +55,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:

--- a/nile_api/api/entities/update_instance.py
+++ b/nile_api/api/entities/update_instance.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -45,12 +46,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Instance]:
         response_200 = Instance.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Instance]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/aggregate_metrics.py
+++ b/nile_api/api/metrics/aggregate_metrics.py
@@ -6,6 +6,7 @@ import httpx
 from ...client import Client
 from ...models.aggregation_request import AggregationRequest
 from ...models.bucket import Bucket
+from ...models.error import Error
 from ...types import Response
 
 
@@ -53,7 +54,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Bucket]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Bucket]]:

--- a/nile_api/api/metrics/aggregate_metrics.py
+++ b/nile_api/api/metrics/aggregate_metrics.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -44,12 +45,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Bucket]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Bucket]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/filter_metrics.py
+++ b/nile_api/api/metrics/filter_metrics.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.filter_ import Filter
 from ...models.metric import Metric
 from ...types import Response
@@ -52,7 +53,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Metric]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Metric]]:

--- a/nile_api/api/metrics/filter_metrics.py
+++ b/nile_api/api/metrics/filter_metrics.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -43,12 +44,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Metric]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Metric]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/filter_metrics_for_entity_type.py
+++ b/nile_api/api/metrics/filter_metrics_for_entity_type.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -44,12 +45,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Metric]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Metric]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/filter_metrics_for_entity_type.py
+++ b/nile_api/api/metrics/filter_metrics_for_entity_type.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.filter_ import Filter
 from ...models.metric import Metric
 from ...types import Response
@@ -53,7 +54,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Metric]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Metric]]:

--- a/nile_api/api/metrics/list_metric_definitions.py
+++ b/nile_api/api/metrics/list_metric_definitions.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -37,14 +38,22 @@ def _parse_response(
         response_200 = ListMetricDefinitionsResponse.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[ListMetricDefinitionsResponse]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/list_metric_definitions.py
+++ b/nile_api/api/metrics/list_metric_definitions.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.list_metric_definitions_response import (
     ListMetricDefinitionsResponse,
 )
@@ -46,7 +47,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/metrics/list_metric_definitions_for_entity_type.py
+++ b/nile_api/api/metrics/list_metric_definitions_for_entity_type.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -38,14 +39,22 @@ def _parse_response(
         response_200 = ListMetricDefinitionsResponse.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[ListMetricDefinitionsResponse]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/metrics/list_metric_definitions_for_entity_type.py
+++ b/nile_api/api/metrics/list_metric_definitions_for_entity_type.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.list_metric_definitions_response import (
     ListMetricDefinitionsResponse,
 )
@@ -47,7 +48,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/metrics/produce_batch_of_metrics.py
+++ b/nile_api/api/metrics/produce_batch_of_metrics.py
@@ -56,7 +56,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/metrics/produce_batch_of_metrics.py
+++ b/nile_api/api/metrics/produce_batch_of_metrics.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union, cast
 
 import httpx
@@ -47,14 +48,22 @@ def _parse_response(
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Any, Error]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/accept_invite.py
+++ b/nile_api/api/organizations/accept_invite.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -31,7 +32,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/organizations/add_user_to_org.py
+++ b/nile_api/api/organizations/add_user_to_org.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.add_user_to_org_request import AddUserToOrgRequest
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/organizations/add_user_to_org.py
+++ b/nile_api/api/organizations/add_user_to_org.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_200 = User.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/create_organization.py
+++ b/nile_api/api/organizations/create_organization.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.create_organization_request import CreateOrganizationRequest
+from ...models.error import Error
 from ...models.organization import Organization
 from ...types import Response
 
@@ -47,7 +48,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:

--- a/nile_api/api/organizations/create_organization.py
+++ b/nile_api/api/organizations/create_organization.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -38,12 +39,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
         response_201 = Organization.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/delete_organization.py
+++ b/nile_api/api/organizations/delete_organization.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -30,7 +31,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/organizations/get_organization.py
+++ b/nile_api/api/organizations/get_organization.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.organization import Organization
 from ...types import Response
 
@@ -43,7 +44,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:

--- a/nile_api/api/organizations/get_organization.py
+++ b/nile_api/api/organizations/get_organization.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -34,12 +35,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
         response_200 = Organization.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/list_invites.py
+++ b/nile_api/api/organizations/list_invites.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Invite]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Invite]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/list_invites.py
+++ b/nile_api/api/organizations/list_invites.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.invite import Invite
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Invite]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Invite]]:

--- a/nile_api/api/organizations/list_organizations.py
+++ b/nile_api/api/organizations/list_organizations.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.organization import Organization
 from ...types import Response
 
@@ -49,7 +50,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/organizations/list_organizations.py
+++ b/nile_api/api/organizations/list_organizations.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -40,14 +41,22 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[List[Organization]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/list_users_in_org.py
+++ b/nile_api/api/organizations/list_users_in_org.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[User]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[User]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/list_users_in_org.py
+++ b/nile_api/api/organizations/list_users_in_org.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[User]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[User]]:

--- a/nile_api/api/organizations/remove_user_from_org.py
+++ b/nile_api/api/organizations/remove_user_from_org.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -31,7 +32,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/organizations/update_organization.py
+++ b/nile_api/api/organizations/update_organization.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
         response_200 = Organization.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/update_organization.py
+++ b/nile_api/api/organizations/update_organization.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.organization import Organization
 from ...models.update_organization_request import UpdateOrganizationRequest
 from ...types import Response
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Organization]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Organization]:

--- a/nile_api/api/organizations/update_user_in_org.py
+++ b/nile_api/api/organizations/update_user_in_org.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -42,12 +43,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_200 = User.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/organizations/update_user_in_org.py
+++ b/nile_api/api/organizations/update_user_in_org.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.update_organization_membership_request import (
     UpdateOrganizationMembershipRequest,
 )
@@ -51,7 +52,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/create_developer_owned_user.py
+++ b/nile_api/api/users/create_developer_owned_user.py
@@ -7,6 +7,7 @@ from ...client import Client
 from ...models.create_developer_owned_user_request import (
     CreateDeveloperOwnedUserRequest,
 )
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -49,7 +50,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/create_developer_owned_user.py
+++ b/nile_api/api/users/create_developer_owned_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -40,12 +41,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_201 = User.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/create_user.py
+++ b/nile_api/api/users/create_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -38,12 +39,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_201 = User.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/create_user.py
+++ b/nile_api/api/users/create_user.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.create_user_request import CreateUserRequest
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -47,7 +48,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/delete_user.py
+++ b/nile_api/api/users/delete_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -30,7 +31,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/users/get_user.py
+++ b/nile_api/api/users/get_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -34,12 +35,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_200 = User.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/get_user.py
+++ b/nile_api/api/users/get_user.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -43,7 +44,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/list_users.py
+++ b/nile_api/api/users/list_users.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -47,7 +48,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[User]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[User]]:

--- a/nile_api/api/users/list_users.py
+++ b/nile_api/api/users/list_users.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -38,12 +39,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[User]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[User]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/login_user.py
+++ b/nile_api/api/users/login_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -45,14 +46,22 @@ def _parse_response(
         response_401 = Error.from_dict(response.json())
 
         return response_401
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Error, Token]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/login_user.py
+++ b/nile_api/api/users/login_user.py
@@ -54,7 +54,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/users/me.py
+++ b/nile_api/api/users/me.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -30,12 +31,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_200 = User.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/me.py
+++ b/nile_api/api/users/me.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.user import User
 from ...types import Response
 
@@ -39,7 +40,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/token.py
+++ b/nile_api/api/users/token.py
@@ -46,7 +46,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/users/token.py
+++ b/nile_api/api/users/token.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -37,14 +38,22 @@ def _parse_response(
         response_401 = Error.from_dict(response.json())
 
         return response_401
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Error, Token]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/update_user.py
+++ b/nile_api/api/users/update_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -39,12 +40,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
         response_200 = User.from_dict(response.json())
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/users/update_user.py
+++ b/nile_api/api/users/update_user.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.update_user_request import UpdateUserRequest
 from ...models.user import User
 from ...types import Response
@@ -48,7 +49,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[User]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[User]:

--- a/nile_api/api/users/validate_user.py
+++ b/nile_api/api/users/validate_user.py
@@ -52,7 +52,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/users/validate_user.py
+++ b/nile_api/api/users/validate_user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union, cast
 
 import httpx
@@ -43,14 +44,22 @@ def _parse_response(
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Any, Error]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/create_access_token.py
+++ b/nile_api/api/workspaces/create_access_token.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -40,14 +41,22 @@ def _parse_response(
         response_201 = CreateAccessTokenResponse.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[CreateAccessTokenResponse]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/create_access_token.py
+++ b/nile_api/api/workspaces/create_access_token.py
@@ -6,6 +6,7 @@ import httpx
 from ...client import Client
 from ...models.create_access_token_request import CreateAccessTokenRequest
 from ...models.create_access_token_response import CreateAccessTokenResponse
+from ...models.error import Error
 from ...types import Response
 
 
@@ -49,7 +50,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/workspaces/create_workspace.py
+++ b/nile_api/api/workspaces/create_workspace.py
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import Client
 from ...models.create_workspace_request import CreateWorkspaceRequest
+from ...models.error import Error
 from ...models.workspace import Workspace
 from ...types import Response
 
@@ -44,7 +45,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[Workspace]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Workspace]:

--- a/nile_api/api/workspaces/create_workspace.py
+++ b/nile_api/api/workspaces/create_workspace.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import httpx
@@ -35,12 +36,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[Workspace]:
         response_201 = Workspace.from_dict(response.json())
 
         return response_201
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[Workspace]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/delete_access_token.py
+++ b/nile_api/api/workspaces/delete_access_token.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict
 
 import httpx
@@ -30,7 +31,7 @@ def _get_kwargs(
 
 def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=None,

--- a/nile_api/api/workspaces/get_access_token.py
+++ b/nile_api/api/workspaces/get_access_token.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -45,14 +46,22 @@ def _parse_response(
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[AccessTokenInfo, Error]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/get_access_token.py
+++ b/nile_api/api/workspaces/get_access_token.py
@@ -54,7 +54,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/workspaces/get_workspace_open_api.py
+++ b/nile_api/api/workspaces/get_workspace_open_api.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union, cast
 
 import httpx
@@ -38,14 +39,22 @@ def _parse_response(
         response_401 = Error.from_dict(response.json())
 
         return response_401
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Error, str]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/get_workspace_open_api.py
+++ b/nile_api/api/workspaces/get_workspace_open_api.py
@@ -47,7 +47,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/workspaces/list_access_tokens.py
+++ b/nile_api/api/workspaces/list_access_tokens.py
@@ -60,7 +60,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/workspaces/list_access_tokens.py
+++ b/nile_api/api/workspaces/list_access_tokens.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
@@ -51,14 +52,22 @@ def _parse_response(
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[Error, List[AccessTokenInfo]]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/list_workspaces.py
+++ b/nile_api/api/workspaces/list_workspaces.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -35,12 +36,20 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Workspace]]:
             response_200.append(response_200_item)
 
         return response_200
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Workspace]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/nile_api/api/workspaces/list_workspaces.py
+++ b/nile_api/api/workspaces/list_workspaces.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from ...client import Client
+from ...models.error import Error
 from ...models.workspace import Workspace
 from ...types import Response
 
@@ -44,7 +45,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[List[Workspace]]:
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(*, response: httpx.Response) -> Response[List[Workspace]]:

--- a/nile_api/api/workspaces/update_access_token.py
+++ b/nile_api/api/workspaces/update_access_token.py
@@ -59,7 +59,7 @@ def _parse_response(
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(

--- a/nile_api/api/workspaces/update_access_token.py
+++ b/nile_api/api/workspaces/update_access_token.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -50,14 +51,22 @@ def _parse_response(
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    return None
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code >= 400 and response.status_code < 500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
 
 
 def _build_response(
     *, response: httpx.Response
 ) -> Response[Union[AccessTokenInfo, Error]]:
     return Response(
-        status_code=response.status_code,
+        status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(response=response),

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,7 @@ OPENAPI_PATH = ROOT / "spec/api.yaml"
 GENERATE_REQUIREMENTS = ROOT / "openapi-generator-requirements"
 GENERATE_CONFIG = ROOT / "openapi-generator-config.yml"
 TESTS = ROOT / "tests/"
+TEMPLATES = ROOT / "templates"
 
 nox.options.sessions = []
 
@@ -30,6 +31,9 @@ def session(default=True, **kwargs):
 @session(python=["3.7", "3.8", "3.9", "3.10", "pypy3"])
 def tests(session):
     session.install("pytest")
+    # needed for importing events module
+    session.install("httpx")
+    session.install("python-dateutil")
     session.run("pytest", "-s", str(TESTS))
 
 
@@ -75,6 +79,8 @@ def regenerate(session):
             str(OPENAPI_PATH),
             "--config",
             str(GENERATE_CONFIG),  # str() until wntrblm/nox#649 is released
+            "--custom-template-path",
+            str(TEMPLATES),
         )
         # We need to run cp because openapi-python-client doesn't support
         # ignoring files and just deletes everything in API_DIR when generating.

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -5,6 +5,7 @@ import httpx
 
 from ...client import AuthenticatedClient, Client
 from ...types import Response, UNSET
+from ...models.error import Error
 
 {% for relative in endpoint.relative_imports %}
 {{ relative }}
@@ -78,9 +79,7 @@ def _parse_response(*, response: httpx.Response) -> Optional[{{ return_string }}
 
     # If it isn't 20X and isn't 40X, we don't know what to do.
     # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
-    raise Exception(f"Unexpected status code: {response.status_code}")
-    
-
+    raise RuntimeError(f"Unexpected status code: {response.status_code}")
 {% endif %}
 
 def _build_response(*, response: httpx.Response) -> Response[{{ return_string }}]:

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -1,0 +1,151 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+
+{% for relative in endpoint.relative_imports %}
+{{ relative }}
+{% endfor %}
+
+{% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params, json_body, multipart_body,
+    arguments, client, kwargs, parse_response, docstring %}
+
+{% set return_string = endpoint.response_type() %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+
+def _get_kwargs(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Dict[str, Any]:
+    url = "{}{{ endpoint.path }}".format(
+        client.base_url
+        {%- for parameter in endpoint.path_parameters.values() -%}
+        ,{{parameter.name}}={{parameter.python_name}}
+        {%- endfor -%}
+    )
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    {{ header_params(endpoint) | indent(4) }}
+
+    {{ cookie_params(endpoint) | indent(4) }}
+
+    {{ query_params(endpoint) | indent(4) }}
+
+    {{ json_body(endpoint) | indent(4) }}
+
+    {{ multipart_body(endpoint) | indent(4) }}
+
+    return {
+	    "method": "{{ endpoint.method }}",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        {% if endpoint.form_body %}
+        "data": form_data.to_dict(),
+        {% elif endpoint.multipart_body %}
+        "files": {{ "multipart_" + endpoint.multipart_body.python_name }},
+        {% elif endpoint.json_body %}
+        "json": {{ "json_" + endpoint.json_body.python_name }},
+        {% endif %}
+        {% if endpoint.query_parameters %}
+        "params": params,
+        {% endif %}
+    }
+
+
+{% if parsed_responses %}
+def _parse_response(*, response: httpx.Response) -> Optional[{{ return_string }}]:
+    {% for response in endpoint.responses %}
+    if response.status_code == {{ response.status_code }}:
+        {% import "property_templates/" + response.prop.template as prop_template %}
+        {% if prop_template.construct %}
+        {{ prop_template.construct(response.prop, response.source) | indent(8) }}
+        {% else %}
+        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source }})
+        {% endif %}
+        return {{ response.prop.python_name }}
+    {% endfor %}
+
+    # Nile has a known format for 40X errors, so regardless of the spec, lets return a Nile error
+    # Note that the type hint may or may not include Error type
+    if response.status_code>=400 and response.status_code<500:
+        return Error.from_dict(response.json())
+
+    # If it isn't 20X and isn't 40X, we don't know what to do.
+    # This is a hard-coded version of https://github.com/openapi-generators/openapi-python-client/pull/593
+    raise Exception(f"Unexpected status code: {response.status_code}")
+    
+
+{% endif %}
+
+def _build_response(*, response: httpx.Response) -> Response[{{ return_string }}]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        {% if parsed_responses %}
+        parsed=_parse_response(response=response),
+        {% else %}
+        parsed=None,
+        {% endif %}
+    )
+
+
+def sync_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint) }}
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(response=response)
+
+{% if parsed_responses %}
+def sync(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string) | indent(4) }}
+
+    return sync_detailed(
+        {{ kwargs(endpoint) }}
+    ).parsed
+{% endif %}
+
+async def asyncio_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint) }}
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(
+            **kwargs
+        )
+
+    return _build_response(response=response)
+
+{% if parsed_responses %}
+async def asyncio(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string) | indent(4) }}
+
+    return (await asyncio_detailed(
+        {{ kwargs(endpoint) }}
+    )).parsed
+{% endif %}

--- a/tests/test_nile_api.py
+++ b/tests/test_nile_api.py
@@ -10,6 +10,10 @@ def test_toplevel_contents():
     keys = [key for key in dir(nile_api) if not key.startswith("_")]
     assert set(keys) == set(["AuthenticatedClient", "Client", "client"])
 
+    import nile_api.events
+
+    assert "on" in dir(nile_api.events)
+
 
 def test_packages():
     import importlib


### PR DESCRIPTION
Used a custom generator template to introduce more error handling to each endpoint. 40X will return Error even if this isn't in the OpenAPI spec. Anything that isn't a declared 20X or a 40X will throw an exception. 

This affects all endpoints, so it is a big change. 

Testing:
- Manual validation on `validate_user` endpoint where the spec doesn't match reality and therefore the client was broken (spec documents 400 but Nile returns 401, the success response of 204 is None) and caused users to complain.
- Manual validation on `update_user` with bad input, to check the error response there (spec didn't declare errors at all for this endpoint)
- Run Python QS. 


(also introduced a minor improvement to the smoke tests to check the events module) 

Note: 
This returns Error even when it isn't declared as a valid return type. Type checkers will break on this, but it looks like they will break on many other things too. 